### PR TITLE
Fix assets path in Jekyll 3

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
Access layout metadata in Jekyll 3: http://jekyllrb.com/docs/upgrading/2-to-3/#layout-metadata
